### PR TITLE
perf: reduce Edge Runtime invocations

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -19,5 +19,16 @@ export default auth((req) => {
 })
 
 export const config = {
-    matcher: ["/favorilerim/:path*", "/kalori-takibi/:path*"],
+    /*
+     * Middleware sadece korunan sayfalarda çalışır.
+     * Statik dosyalar, next internal route'lar, PWA servis worker,
+     * workbox cache dosyaları ve API route'ları hariç tutulur.
+     * Bu sayede gereksiz Edge Runtime invocation'ları önlenir.
+     */
+    matcher: [
+        "/favorilerim",
+        "/favorilerim/:path+",
+        "/kalori-takibi",
+        "/kalori-takibi/:path+",
+    ],
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,7 +16,9 @@ const nextConfig = {
 
 const withPWA = (await import("@ducanh2912/next-pwa")).default({
   dest: "public",
-  disable: false, // process.env.NODE_ENV === "development",
+  // Servis worker yalnızca production'da aktif.
+  // Development'ta açık bırakmak gereksiz Edge Request ve cache sorunlarına yol açar.
+  disable: process.env.NODE_ENV === "development",
   register: true,
   skipWaiting: true,
 })


### PR DESCRIPTION
- middleware: narrow matcher to exact protected routes only Wildcard ':path*' replaced with explicit '/route' + '/route/:path+' Static files, _next internals and PWA sw.js are excluded from Edge middleware execution.

- next.config.mjs: disable PWA service worker in development Service worker was running in all environments (disable: false), causing unnecessary background sync and cache misses that count as Edge invocations in Vercel analytics.