### PR TITLE
perf: cache homepage with revalidate, move date to client-side

### DIFF
--- a/app/menu-page.tsx
+++ b/app/menu-page.tsx
@@ -5,12 +5,15 @@ import { MealDetailModal } from "@/components/meal-detail-modal"
 import { MobileBottomNav } from "@/components/mobile-bottom-nav"
 import { MenuCard } from "@/components/menu-card"
 import { Header } from "@/components/header"
+import { getTurkeyDate } from "@/lib/date-utils"
 
 import type { DateRange } from "react-day-picker"
 import type { MenuData } from "@/lib/types"
 
 
-export default function MenuPage({ menuData, initialDate }: { menuData: MenuData, initialDate: string }) {
+export default function MenuPage({ menuData }: { menuData: MenuData }) {
+    // Tarih her zaman client'ta hesaplanır — cache'li sayfada bile doğru değer döner.
+    const initialDate = getTurkeyDate()
 
     const [selectedDateRange, setSelectedDateRange] = useState<DateRange | undefined>(undefined)
     const [selectedMeal, setSelectedMeal] = useState<{ id: string; name: string; calories: number } | null>(null)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,16 @@
 import { loadMenuData } from "@/lib/menu-loader"
-import { getCurrentMonth, getTurkeyDate } from "@/lib/date-utils"
+import { getCurrentMonth } from "@/lib/date-utils"
 import MenuPage from "./menu-page"
 
-export const dynamic = 'force-dynamic'
+// Menü verisi sabah bir kez yenilenir, gün içinde değişmez.
+// Saatte bir revalidate yeterli — force-dynamic gereksiz Edge invocation yaratıyordu.
+// Güncel tarih (getTurkeyDate) ise client-side'da hesaplandığından her zaman doğrudur.
+export const revalidate = 3600 // 1 saat
 
 export default async function Home() {
   try {
     const menuData = await loadMenuData(getCurrentMonth())
-    const initialDate = getTurkeyDate()
-    return <MenuPage menuData={menuData} initialDate={initialDate} />
+    return <MenuPage menuData={menuData} />
   } catch (error) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background">


### PR DESCRIPTION
- Replace force-dynamic with revalidate=3600 on homepage Menu data only changes once per morning, no need to re-render on every request. This was causing 2.2K+ Edge invocations.

- Move getTurkeyDate() from server prop to client-side Date is now computed in MenuPage component directly, ensuring correct timezone even with cached pages.