### PR TITLE
feat: add AUTH_ENABLED feature flag to reduce Vercel edge requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ NEXTAUTH_URL=http://localhost:3000
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 
+# Feature Flags
+# Auth sistemini açıp kapatır. false yapıldığında middleware, SessionProvider
+# ve tüm auth API çağrıları devre dışı kalarak Vercel Edge Request sayısı düşer.
+NEXT_PUBLIC_AUTH_ENABLED=true
+
 # Google SMTP (E-posta Bildirimleri)
 # 2FA aktifken App Password oluşturun: Google Hesabı → Güvenlik → Uygulama Şifreleri
 SMTP_USER=your-email@gmail.com

--- a/app/favorilerim/page.tsx
+++ b/app/favorilerim/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { useSession } from "next-auth/react"
+import { useMenuData } from "@/components/menu-data-provider"
 import { useRouter } from "next/navigation"
 import { Bookmark, Trash2, ArrowLeft, Loader2, Mail, Eye } from "lucide-react"
 import { Button } from "@/components/ui/button"
@@ -18,7 +18,7 @@ interface FavoriteItem {
 }
 
 export default function FavorilerimPage() {
-    const { data: session, status } = useSession()
+    const { session, status } = useMenuData()
     const router = useRouter()
     const [favorites, setFavorites] = useState<FavoriteItem[]>([])
     const [isLoading, setIsLoading] = useState(true)

--- a/app/kalori-takibi/page.tsx
+++ b/app/kalori-takibi/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState, useCallback } from "react"
 import { useMediaQuery } from "@/hooks/use-media-query"
-import { useSession } from "next-auth/react"
+import { useMenuData } from "@/components/menu-data-provider"
 import { useRouter } from "next/navigation"
 import { Flame, ArrowLeft, Loader2, Trash2, ChevronLeft, ChevronRight, Eye } from "lucide-react"
 import { Label, Pie, PieChart } from "recharts"
@@ -110,7 +110,7 @@ const CARDS_PER_PAGE_MOBILE = 4
 
 export default function KaloriTakibiPage() {
     const isMobile = useMediaQuery("(max-width: 767px)")
-    const { data: session, status } = useSession()
+    const { session, status } = useMenuData()
     const router = useRouter()
     const [logs, setLogs] = useState<DayLog[]>([])
     const [isLoading, setIsLoading] = useState(true)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,9 +3,10 @@ import type { Metadata, Viewport } from "next"
 import { Geist, Geist_Mono } from "next/font/google"
 import { Analytics } from "@vercel/analytics/next"
 import { GoogleAnalytics } from "@next/third-parties/google"
-import { SessionProvider } from "next-auth/react"
 import { ThemeProvider } from "@/components/theme-provider"
 import { MenuDataProvider } from "@/components/menu-data-provider"
+import { AUTH_ENABLED } from "@/lib/feature-flags"
+import { AuthSessionProvider } from "@/components/auth-session-provider"
 
 import { Toaster } from "@/components/ui/sonner"
 import "./globals.css"
@@ -64,12 +65,12 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <SessionProvider>
+          <AuthSessionProvider>
             <MenuDataProvider>
               {children}
             </MenuDataProvider>
             <Toaster />
-          </SessionProvider>
+          </AuthSessionProvider>
           <Analytics />
           {process.env.NEXT_PUBLIC_GA_ID && (
             <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />

--- a/components/add-meal-button.tsx
+++ b/components/add-meal-button.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useState } from "react"
-import { useSession } from "next-auth/react"
 import { Plus, Check } from "lucide-react"
 import { motion, AnimatePresence } from "framer-motion"
 import { toast } from "sonner"
@@ -10,6 +9,7 @@ import { AuthDrawer } from "@/components/auth-drawer"
 import { CalorieGoalModal } from "@/components/calorie-goal-modal"
 import { useDailyLog } from "@/hooks/use-daily-log"
 import { useCalorieGoal } from "@/hooks/use-calorie-goal"
+import { useMenuData } from "@/components/menu-data-provider"
 
 interface AddMealButtonProps {
     mealName: string
@@ -19,7 +19,7 @@ interface AddMealButtonProps {
 }
 
 export function AddMealButton({ mealName, calories, mealId, menuDate }: AddMealButtonProps) {
-    const { data: session } = useSession()
+    const { session } = useMenuData()
     const { isConsumed, addMeal, removeMeal } = useDailyLog(menuDate)
     const { calorieGoal, needsGoal, setCalorieGoal } = useCalorieGoal()
     const [showAuthDrawer, setShowAuthDrawer] = useState(false)

--- a/components/auth-button.tsx
+++ b/components/auth-button.tsx
@@ -5,6 +5,7 @@ import { useSession, signIn, signOut } from "next-auth/react"
 import { Bookmark, Flame, LogOut } from "lucide-react"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
+import { AUTH_ENABLED } from "@/lib/feature-flags"
 import {
     Avatar,
     AvatarFallback,
@@ -59,20 +60,29 @@ function GoogleIcon({ className }: { className?: string }) {
     )
 }
 
-function AuthDialogContent({ onSignIn }: { onSignIn: () => void }) {
+function AuthDialogContent({ onSignIn, disabled }: { onSignIn: () => void; disabled?: boolean }) {
     return (
         <div className="flex flex-col items-center gap-4 py-2">
+            {disabled && (
+                <span className="inline-flex items-center rounded-full bg-amber-500/10 border border-amber-500/20 px-2.5 py-1 text-[11px] font-medium text-amber-600 dark:text-amber-400">
+                    Giriş sistemi geçici olarak devre dışı
+                </span>
+            )}
             <Button
                 className="w-full h-11 gap-3 text-sm font-medium"
                 variant="outline"
                 onClick={onSignIn}
+                disabled={disabled}
             >
                 <GoogleIcon className="h-5 w-5" />
                 Google ile Giriş Yap
             </Button>
             <div className="space-y-2 text-center">
                 <p className="text-[11px] text-muted-foreground/60">
-                    Yalnızca Google hesabınızla giriş yapabilirsiniz.
+                    {disabled
+                        ? "Sistem bakım nedeniyle geçici olarak kapatılmıştır."
+                        : "Yalnızca Google hesabınızla giriş yapabilirsiniz."
+                    }
                 </p>
             </div>
         </div>
@@ -80,6 +90,84 @@ function AuthDialogContent({ onSignIn }: { onSignIn: () => void }) {
 }
 
 export function AuthButton() {
+    // Auth kapalıysa useSession çağırmıyoruz — hook'ları koşullu çağıramayız
+    // ama SessionProvider olmayınca useSession zaten undefined döner.
+    // AUTH_ENABLED false iken SessionProvider yok, bu yüzden
+    // useSession'ı try etmek yerine direkt disabled UI gösteriyoruz.
+
+    if (!AUTH_ENABLED) {
+        return <AuthButtonDisabled />
+    }
+
+    return <AuthButtonEnabled />
+}
+
+function AuthButtonDisabled() {
+    const [authOpen, setAuthOpen] = useState(false)
+    const isDesktop = useMediaQuery("(min-width: 768px)")
+
+    return (
+        <>
+            <Button
+                variant="outline"
+                size="sm"
+                className="h-8 text-xs px-3 opacity-60 cursor-not-allowed"
+                onClick={() => setAuthOpen(true)}
+            >
+                Giriş Yap
+            </Button>
+
+            {isDesktop ? (
+                <Dialog open={authOpen} onOpenChange={setAuthOpen}>
+                    <DialogContent className="sm:max-w-sm">
+                        <DialogHeader className="text-center">
+                            <DialogTitle className="text-lg">
+                                Giriş Yapın
+                                <span className="ml-2 inline-flex items-center rounded-full bg-amber-500/10 border border-amber-500/20 px-2 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400 align-middle">
+                                    Devre Dışı
+                                </span>
+                            </DialogTitle>
+                            <DialogDescription className="text-sm text-muted-foreground">
+                                Giriş sistemi şu anda geçici olarak devre dışıdır.
+                            </DialogDescription>
+                        </DialogHeader>
+                        <AuthDialogContent onSignIn={() => { }} disabled />
+                    </DialogContent>
+                </Dialog>
+            ) : (
+                <Drawer open={authOpen} onOpenChange={setAuthOpen}>
+                    <DrawerContent>
+                        <div className="mx-auto w-full max-w-sm">
+                            <DrawerHeader className="text-center">
+                                <DrawerTitle className="text-lg">
+                                    Giriş Yapın
+                                    <span className="ml-2 inline-flex items-center rounded-full bg-amber-500/10 border border-amber-500/20 px-2 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400 align-middle">
+                                        Devre Dışı
+                                    </span>
+                                </DrawerTitle>
+                                <DrawerDescription className="text-sm text-muted-foreground">
+                                    Giriş sistemi şu anda geçici olarak devre dışıdır.
+                                </DrawerDescription>
+                            </DrawerHeader>
+                            <div className="px-4 pb-2">
+                                <AuthDialogContent onSignIn={() => { }} disabled />
+                            </div>
+                            <DrawerFooter className="pt-2">
+                                <DrawerClose asChild>
+                                    <Button variant="ghost" size="sm" className="text-xs text-muted-foreground">
+                                        Vazgeç
+                                    </Button>
+                                </DrawerClose>
+                            </DrawerFooter>
+                        </div>
+                    </DrawerContent>
+                </Drawer>
+            )}
+        </>
+    )
+}
+
+function AuthButtonEnabled() {
     const { data: session, status } = useSession()
     const [authOpen, setAuthOpen] = useState(false)
     const isDesktop = useMediaQuery("(min-width: 768px)")

--- a/components/auth-drawer.tsx
+++ b/components/auth-drawer.tsx
@@ -2,6 +2,7 @@
 
 import { signIn } from "next-auth/react"
 import { Button } from "@/components/ui/button"
+import { AUTH_ENABLED } from "@/lib/feature-flags"
 import {
     Drawer,
     DrawerClose,
@@ -47,22 +48,36 @@ export function AuthDrawer({ open, onOpenChange, message }: AuthDrawerProps) {
             <DrawerContent>
                 <div className="mx-auto w-full max-w-sm">
                     <DrawerHeader className="text-center">
-                        <DrawerTitle className="text-lg">Giriş Yapın</DrawerTitle>
+                        <DrawerTitle className="text-lg">
+                            Giriş Yapın
+                            {!AUTH_ENABLED && (
+                                <span className="ml-2 inline-flex items-center rounded-full bg-amber-500/10 border border-amber-500/20 px-2 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-400 align-middle">
+                                    Devre Dışı
+                                </span>
+                            )}
+                        </DrawerTitle>
                         <DrawerDescription className="text-sm text-muted-foreground">
-                            {message || "Bu özelliği kullanabilmek için giriş yapmanız gerekiyor."}
+                            {!AUTH_ENABLED
+                                ? "Giriş sistemi şu anda geçici olarak devre dışıdır. Lütfen daha sonra tekrar deneyin."
+                                : (message || "Bu özelliği kullanabilmek için giriş yapmanız gerekiyor.")
+                            }
                         </DrawerDescription>
                     </DrawerHeader>
                     <div className="px-4 pb-2">
                         <Button
                             className="w-full h-11 gap-3 text-sm font-medium"
                             variant="outline"
-                            onClick={() => signIn("google")}
+                            onClick={() => AUTH_ENABLED && signIn("google")}
+                            disabled={!AUTH_ENABLED}
                         >
                             <GoogleIcon className="h-5 w-5" />
                             Google ile Giriş Yap
                         </Button>
                         <p className="text-center text-[11px] text-muted-foreground/60 mt-3">
-                            Ücretsiz hesabınızla tüm kişisel özelliklere erişin.
+                            {!AUTH_ENABLED
+                                ? "Sistem bakım nedeniyle geçici olarak kapatılmıştır."
+                                : "Ücretsiz hesabınızla tüm kişisel özelliklere erişin."
+                            }
                         </p>
                     </div>
                     <DrawerFooter className="pt-2">

--- a/components/auth-session-provider.tsx
+++ b/components/auth-session-provider.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import { SessionProvider } from "next-auth/react"
+import { AUTH_ENABLED } from "@/lib/feature-flags"
+import type { ReactNode } from "react"
+
+/**
+ * Auth kapalıysa SessionProvider render etmez.
+ * Bu sayede her sayfa yüklemesinde otomatik yapılan
+ * /api/auth/session edge request'i tamamen engellenir.
+ */
+export function AuthSessionProvider({ children }: { children: ReactNode }) {
+    if (!AUTH_ENABLED) {
+        return <>{children}</>
+    }
+
+    return <SessionProvider>{children}</SessionProvider>
+}

--- a/components/favorite-button.tsx
+++ b/components/favorite-button.tsx
@@ -1,20 +1,20 @@
 "use client"
 
 import { useState } from "react"
-import { useSession } from "next-auth/react"
 import { Heart } from "lucide-react"
 import { motion, AnimatePresence } from "framer-motion"
 import { toast } from "sonner"
 import { cn } from "@/lib/utils"
 import { AuthDrawer } from "@/components/auth-drawer"
 import { useFavorites } from "@/hooks/use-favorites"
+import { useMenuData } from "@/components/menu-data-provider"
 
 interface FavoriteButtonProps {
     mealName: string
 }
 
 export function FavoriteButton({ mealName }: FavoriteButtonProps) {
-    const { data: session } = useSession()
+    const { session } = useMenuData()
     const { isFavorited, toggleFavorite } = useFavorites()
     const [showAuthDrawer, setShowAuthDrawer] = useState(false)
     const favorited = isFavorited(mealName)

--- a/components/menu-data-provider.tsx
+++ b/components/menu-data-provider.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from "react"
 import { useSession } from "next-auth/react"
+import { AUTH_ENABLED } from "@/lib/feature-flags"
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -18,8 +19,8 @@ interface DailyLogData {
 
 interface MenuDataContextType {
     // Session
-    session: ReturnType<typeof useSession>["data"]
-    status: ReturnType<typeof useSession>["status"]
+    session: ReturnType<typeof useSession>["data"] | null
+    status: ReturnType<typeof useSession>["status"] | "unauthenticated"
     isAuthenticated: boolean
 
     // Favorites (shared across all MenuCards)
@@ -45,6 +46,45 @@ const MenuDataContext = createContext<MenuDataContextType | null>(null)
 // ─── Provider ────────────────────────────────────────────────────────────────
 
 export function MenuDataProvider({ children }: { children: ReactNode }) {
+    // Auth kapalıysa useSession çağırma — SessionProvider olmayacak
+    if (!AUTH_ENABLED) {
+        return <MenuDataProviderDisabled>{children}</MenuDataProviderDisabled>
+    }
+    return <MenuDataProviderEnabled>{children}</MenuDataProviderEnabled>
+}
+
+// ─── Auth Kapalı Provider ────────────────────────────────────────────────────
+
+function MenuDataProviderDisabled({ children }: { children: ReactNode }) {
+    const emptyDailyLog: DailyLogData = { totalCalories: 0, consumedMeals: [] }
+
+    return (
+        <MenuDataContext.Provider
+            value={{
+                session: null,
+                status: "unauthenticated",
+                isAuthenticated: false,
+                favorites: [],
+                isFavorited: () => false,
+                toggleFavorite: async () => false,
+                calorieGoal: null,
+                calorieGoalLoading: false,
+                needsGoal: false,
+                setCalorieGoal: async () => false,
+                getDailyLog: () => emptyDailyLog,
+                addMeal: async () => false,
+                removeMeal: async () => false,
+                isConsumed: () => false,
+            }}
+        >
+            {children}
+        </MenuDataContext.Provider>
+    )
+}
+
+// ─── Auth Açık Provider ──────────────────────────────────────────────────────
+
+function MenuDataProviderEnabled({ children }: { children: ReactNode }) {
     const { data: session, status } = useSession()
     const isAuthenticated = status === "authenticated"
 

--- a/components/mobile-menu.tsx
+++ b/components/mobile-menu.tsx
@@ -8,6 +8,7 @@ import Link from "next/link"
 import { motion, AnimatePresence } from "framer-motion"
 import { Button } from "@/components/ui/button"
 import { AuthDrawer } from "@/components/auth-drawer"
+import { AUTH_ENABLED } from "@/lib/feature-flags"
 import {
     Avatar,
     AvatarFallback,
@@ -74,6 +75,132 @@ interface MobileMenuProps {
 }
 
 export function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
+    if (!AUTH_ENABLED) {
+        return <MobileMenuDisabled isOpen={isOpen} onClose={onClose} />
+    }
+    return <MobileMenuEnabled isOpen={isOpen} onClose={onClose} />
+}
+
+function MobileMenuDisabled({ isOpen, onClose }: MobileMenuProps) {
+    const { isInstallable, install } = usePwaInstall()
+    const [authDrawerOpen, setAuthDrawerOpen] = useState(false)
+
+    return (
+        <>
+            <AnimatePresence>
+                {isOpen && (
+                    <motion.div
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.2 }}
+                        className="fixed inset-0 z-[60] dark text-foreground bg-background"
+                    >
+                        {/* Header with close button */}
+                        <div className="container mx-auto px-4 py-3">
+                            <div className="flex items-center justify-end min-h-9">
+                                <button
+                                    onClick={onClose}
+                                    className="flex items-center justify-center h-8 w-8 rounded-full border border-border/60 text-muted-foreground hover:text-foreground transition-colors"
+                                >
+                                    <motion.svg
+                                        initial={{ rotate: -90 }}
+                                        animate={{ rotate: 0 }}
+                                        transition={{ duration: 0.25, ease: "easeOut" }}
+                                        width="16" height="16" viewBox="0 0 16 16" fill="currentColor" strokeLinejoin="round" style={{ color: 'currentcolor' }}
+                                    >
+                                        <path fillRule="evenodd" clipRule="evenodd" d="M12.4697 13.5303L13 14.0607L14.0607 13L13.5303 12.4697L9.06065 7.99999L13.5303 3.53032L14.0607 2.99999L13 1.93933L12.4697 2.46966L7.99999 6.93933L3.53032 2.46966L2.99999 1.93933L1.93933 2.99999L2.46966 3.53032L6.93933 7.99999L2.46966 12.4697L1.93933 13L2.99999 14.0607L3.53032 13.5303L7.99999 9.06065L12.4697 13.5303Z" />
+                                    </motion.svg>
+                                </button>
+                            </div>
+                        </div>
+
+                        {/* Scrollable content */}
+                        <div className="flex-1 overflow-y-auto">
+                            <div className="px-5 pt-2 pb-8">
+                                {/* Auth disabled banner + disabled button */}
+                                <div className="space-y-2.5 mb-5">
+                                    <Button
+                                        className="w-full h-10 text-sm font-medium gap-3"
+                                        disabled
+                                    >
+                                        <GoogleIcon className="h-5 w-5" />
+                                        Google ile Giriş Yap
+                                        <span className="inline-flex items-center rounded-full bg-amber-500/10 border border-amber-500/20 px-1.5 py-0 text-[9px] font-medium text-amber-600 dark:text-amber-400">
+                                            Devre Dışı
+                                        </span>
+                                    </Button>
+                                    <Button
+                                        variant="outline"
+                                        className="w-full h-10 text-sm font-medium border-border/60"
+                                        asChild
+                                    >
+                                        <Link href="mailto:hi@umutcan.xyz">
+                                            İletişime Geç
+                                        </Link>
+                                    </Button>
+                                </div>
+
+                                {/* Navigation Links — unauth mode */}
+                                <nav>
+                                    <Link
+                                        href="/"
+                                        onClick={onClose}
+                                        className="flex items-center justify-between h-12 px-1 text-base text-muted-foreground hover:text-foreground transition-colors"
+                                    >
+                                        <span>Ana Sayfa</span>
+                                        <Home className="h-4 w-4" />
+                                    </Link>
+                                    <button
+                                        onClick={() => setAuthDrawerOpen(true)}
+                                        className="flex items-center justify-between h-12 px-1 text-base text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+                                    >
+                                        <span>Favorilerim</span>
+                                        <Bookmark className="h-4 w-4" />
+                                    </button>
+                                    <button
+                                        onClick={() => setAuthDrawerOpen(true)}
+                                        className="flex items-center justify-between h-12 px-1 text-base text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+                                    >
+                                        <span>Kalori Takibi</span>
+                                        <Flame className="h-4 w-4" />
+                                    </button>
+
+                                    {isInstallable && (
+                                        <button
+                                            onClick={() => {
+                                                install()
+                                                onClose()
+                                            }}
+                                            className="flex items-center justify-between h-12 px-1 text-base text-muted-foreground hover:text-foreground transition-colors w-full text-left"
+                                        >
+                                            <span>Uygulamayı Yükle</span>
+                                            <Download className="h-4 w-4" />
+                                        </button>
+                                    )}
+                                </nav>
+
+                                {/* Theme Toggle */}
+                                <div>
+                                    <ThemeToggleBar />
+                                </div>
+                            </div>
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+
+            {/* Auth Drawer */}
+            <AuthDrawer
+                open={authDrawerOpen}
+                onOpenChange={setAuthDrawerOpen}
+                message="Bu özelliği kullanabilmek için giriş yapmanız gerekiyor."
+            />
+        </>
+    )
+}
+
+function MobileMenuEnabled({ isOpen, onClose }: MobileMenuProps) {
     const { data: session, status } = useSession()
     const { isInstallable, install } = usePwaInstall()
     const [isSigningIn, setIsSigningIn] = useState(false)

--- a/hooks/use-calorie-goal.ts
+++ b/hooks/use-calorie-goal.ts
@@ -1,10 +1,10 @@
 "use client"
 
 import { useState, useEffect, useCallback } from "react"
-import { useSession } from "next-auth/react"
+import { useMenuData } from "@/components/menu-data-provider"
 
 export function useCalorieGoal() {
-    const { data: session } = useSession()
+    const { session } = useMenuData()
     const [calorieGoal, setCalorieGoalState] = useState<number | null>(null)
     const [isLoading, setIsLoading] = useState(true)
 

--- a/hooks/use-daily-log.ts
+++ b/hooks/use-daily-log.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect, useCallback } from "react"
-import { useSession } from "next-auth/react"
+import { useMenuData } from "@/components/menu-data-provider"
 
 interface ConsumedMeal {
     mealName: string
@@ -10,7 +10,7 @@ interface ConsumedMeal {
 }
 
 export function useDailyLog(date: string) {
-    const { data: session } = useSession()
+    const { session } = useMenuData()
     const [totalCalories, setTotalCalories] = useState(0)
     const [consumedMeals, setConsumedMeals] = useState<ConsumedMeal[]>([])
     const [isLoading, setIsLoading] = useState(false)

--- a/hooks/use-favorites.ts
+++ b/hooks/use-favorites.ts
@@ -1,10 +1,10 @@
 "use client"
 
 import { useState, useEffect, useCallback } from "react"
-import { useSession } from "next-auth/react"
+import { useMenuData } from "@/components/menu-data-provider"
 
 export function useFavorites() {
-    const { data: session } = useSession()
+    const { session } = useMenuData()
     const [favorites, setFavorites] = useState<string[]>([])
     const [isLoading, setIsLoading] = useState(false)
 

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -1,0 +1,12 @@
+/**
+ * Feature Flags
+ * 
+ * Vercel Edge Request limitlerini yönetmek için merkezi feature flag sistemi.
+ * AUTH_ENABLED=false yapıldığında:
+ * - Middleware auth kontrolü atlanır (edge request düşer)
+ * - SessionProvider devre dışı kalır (otomatik /api/auth/session çağrısı yok)
+ * - API route'lardaki auth() çağrıları atlanır
+ * - UI'da giriş butonları "Devre Dışı" olarak gösterilir
+ */
+
+export const AUTH_ENABLED = process.env.NEXT_PUBLIC_AUTH_ENABLED !== "false"

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,22 +1,33 @@
-import { auth } from "@/lib/auth"
 import { NextResponse } from "next/server"
+import type { NextRequest } from "next/server"
+
+// AUTH_ENABLED kontrolü — build-time'da sabitlenir
+const AUTH_ENABLED = process.env.NEXT_PUBLIC_AUTH_ENABLED !== "false"
 
 // Protected routes that require authentication
 const protectedRoutes = ["/favorilerim", "/kalori-takibi"]
 
-export default auth((req) => {
-    const { pathname } = req.nextUrl
+export default async function middleware(req: NextRequest) {
+    // Auth kapalıysa middleware hiçbir şey yapmaz — edge request minimuma iner
+    if (!AUTH_ENABLED) {
+        return NextResponse.next()
+    }
 
+    // Auth açıkken dinamik import ile auth fonksiyonunu yükle
+    const { auth } = await import("@/lib/auth")
+    const session = await auth()
+
+    const { pathname } = req.nextUrl
     const isProtected = protectedRoutes.some((route) => pathname.startsWith(route))
 
-    if (isProtected && !req.auth) {
+    if (isProtected && !session) {
         const url = req.nextUrl.clone()
         url.pathname = "/"
         return NextResponse.redirect(url)
     }
 
     return NextResponse.next()
-})
+}
 
 export const config = {
     /*


### PR DESCRIPTION
- Add NEXT_PUBLIC_AUTH_ENABLED env variable to toggle auth system
- Middleware skips auth check when disabled (no edge invocation)
- SessionProvider conditionally rendered via AuthSessionProvider
- All useSession calls replaced with useMenuData (safe when no provider)
- Auth drawer/button show 'Devre Disi' badge when auth disabled
- Mobile menu shows disabled Google sign-in button
- Zero API calls for favorites, calorie-goal, daily-log when disabled
- Updated .env.example with feature flag documentation