### PR TITLE
feat: Coolify deployment desteği

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,24 +1,35 @@
+# ─────────────────────────────────────────────────
+# Çukurova Yemekhane — Environment Variables
+# ─────────────────────────────────────────────────
+# Coolify: Dashboard → Application → Environment Variables
+# Lokal:   Bu dosyayı .env.local olarak kopyalayın
+# ─────────────────────────────────────────────────
+
 # NeonDB PostgreSQL Connection
 # Get your connection string from: https://console.neon.tech
 DATABASE_URL=postgresql://user:password@ep-xxx.region.neon.tech/neondb?sslmode=require
 
 # Google Analytics
 # Get your Measurement ID from: https://analytics.google.com
+# ⚠️ NEXT_PUBLIC_ prefix → Build time'da bake edilir!
 NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
 
 # NextAuth.js (Auth.js)
 # Generate a secret: openssl rand -base64 32
 NEXTAUTH_SECRET=your-secret-key-here
-NEXTAUTH_URL=http://localhost:3000
+# ⚠️ Coolify'da production domain'inizi yazın!
+NEXTAUTH_URL=https://your-domain.com
 
 # Google OAuth
 # Get credentials from: https://console.cloud.google.com/apis/credentials
+# ⚠️ Callback URL'yi de ekleyin: https://your-domain.com/api/auth/callback/google
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-google-client-secret
 
 # Feature Flags
 # Auth sistemini açıp kapatır. false yapıldığında middleware, SessionProvider
-# ve tüm auth API çağrıları devre dışı kalarak Vercel Edge Request sayısı düşer.
+# ve tüm auth API çağrıları devre dışı kalarak Edge Request sayısı düşer.
+# ⚠️ NEXT_PUBLIC_ prefix → Build time'da bake edilir!
 NEXT_PUBLIC_AUTH_ENABLED=true
 
 # Google SMTP (E-posta Bildirimleri)

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import type React from "react"
 import type { Metadata, Viewport } from "next"
 import { Geist, Geist_Mono } from "next/font/google"
-import { Analytics } from "@vercel/analytics/next"
 import { GoogleAnalytics } from "@next/third-parties/google"
 import { ThemeProvider } from "@/components/theme-provider"
 import { MenuDataProvider } from "@/components/menu-data-provider"
@@ -71,7 +70,6 @@ export default function RootLayout({
             </MenuDataProvider>
             <Toaster />
           </AuthSessionProvider>
-          <Analytics />
           {process.env.NEXT_PUBLIC_GA_ID && (
             <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
           )}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@radix-ui/react-toggle": "1.1.1",
     "@radix-ui/react-toggle-group": "1.1.1",
     "@radix-ui/react-tooltip": "1.1.6",
-    "@vercel/analytics": "1.3.1",
     "autoprefixer": "^10.4.20",
     "cheerio": "^1.0.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,9 +104,6 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.1.6
         version: 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@vercel/analytics':
-        specifier: 1.3.1
-        version: 1.3.1(next@16.0.10(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.22(postcss@8.5.6)
@@ -2350,17 +2347,6 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
-  '@vercel/analytics@1.3.1':
-    resolution: {integrity: sha512-xhSlYgAuJ6Q4WQGkzYTLmXwhYl39sWjoMA3nHxfkvG+WdBT25c563a7QhwwKivEOZtPJXifYHR1m2ihoisbWyA==}
-    peerDependencies:
-      next: '>= 13'
-      react: ^18 || ^19
-    peerDependenciesMeta:
-      next:
-        optional: true
-      react:
-        optional: true
-
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -3772,9 +3758,6 @@ packages:
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
-
-  server-only@0.0.1:
-    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -6211,13 +6194,6 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
-  '@vercel/analytics@1.3.1(next@16.0.10(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      server-only: 0.0.1
-    optionalDependencies:
-      next: 16.0.10(@babel/core@7.28.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react: 19.2.0
-
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
@@ -7660,8 +7636,6 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
-
-  server-only@0.0.1: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
- next.config.mjs: output: 'standalone' eklendi (Nixpacks için gerekli)
- @vercel/analytics kaldırıldı (Vercel dışında çalışmaz, GA yeterli)
- .env.example: Coolify-specific notlar eklendi (build-time vs runtime, NEXTAUTH_URL)