### PR TITLE
chore(workflows): scrape ve notify'ı tamamen izole et, otomatik tetikten çıkar

### DIFF
--- a/.github/workflows/menu-notify.yml
+++ b/.github/workflows/menu-notify.yml
@@ -1,28 +1,15 @@
 name: Favori Bildirimleri Gönder
 
 on:
-  workflow_run:
-    workflows: ["Menüyü Scrape Et"]
-    types:
-      - completed
-    branches:
-      - main
+  repository_dispatch:
+    types: [trigger-notify]
+  workflow_dispatch:
 
 jobs:
   send-notifications:
     runs-on: ubuntu-latest
-    # Sadece scrape workflow'u başarılıysa ve cron ile tetiklendiyse çalış
-    # workflow_dispatch ile tetiklenen scrape'lerde mail GÖNDERMEZ
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'schedule'
 
     steps:
-      - name: Deploy'un Tamamlanmasını Bekle
-        run: |
-          echo "Coolify deploy'unun tamamlanması için 10 dakika bekleniyor..."
-          sleep 600
-
       - name: Depoyu Çek (Checkout)
         uses: actions/checkout@v6
 

--- a/.github/workflows/menu-scrape.yml
+++ b/.github/workflows/menu-scrape.yml
@@ -1,8 +1,8 @@
 name: Menüyü Scrape Et
 
 on:
-  schedule:
-    - cron: '20 3 * * 1-5'  # Sabah 06:20 (UTC+3)
+  repository_dispatch:
+    types: [trigger-scrape]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
- menu-scrape.yml: schedule (cron) kaldırıldı. Sadece repository_dispatch
  (trigger-scrape) ve workflow_dispatch ile çalışır.
- menu-notify.yml: scrape'e olan workflow_run bağımlılığı tamamen kaldırıldı.
  10 dakikalık sleep ve event=='schedule' if koşulu silindi. Sadece
  repository_dispatch (trigger-notify) ve workflow_dispatch ile çalışır.

İki workflow artık birbirinden tamamen bağımsız; harici bir cron servisi
(cron-job.org vb.) her birini ayrı ayrı tetikleyecek.

https://claude.ai/code/session_01DqqTN7Ps42T6savotrbNfX